### PR TITLE
⏹ Also delete users message

### DIFF
--- a/RavenBOT.Services.Reactive/ReactivePagerCallback.cs
+++ b/RavenBOT.Services.Reactive/ReactivePagerCallback.cs
@@ -131,6 +131,7 @@ namespace RavenBOT.Common
         public async Task<bool> TrashAsync()
         {
             await Message.DeleteAsync().ConfigureAwait(false);
+            await Context.Message.DeleteAsync();
             return true;
         }
 


### PR DESCRIPTION
Also delete the users message when reacting to ⏹ "TrashAsync", to help cleaning up channels.